### PR TITLE
Preview description for items

### DIFF
--- a/catalog/controller/product/category.php
+++ b/catalog/controller/product/category.php
@@ -197,7 +197,7 @@ class ControllerProductCategory extends Controller {
 					'product_id'  => $result['product_id'],
 					'thumb'       => $image,
 					'name'        => $result['name'],
-					'description' => utf8_substr(trim(strip_tags(html_entity_decode($result['description'], ENT_QUOTES, 'UTF-8'))), 0, $this->config->get('theme_' . $this->config->get('config_theme') . '_product_description_length')) . '..',
+					'description' => utf8_substr(preg_replace("/<([a-z][a-z0-9]*)[^>]*?(\/?)>/i",'<$1$2>', strip_tags(html_entity_decode($result['description'], ENT_QUOTES), "<p><br>")), 0, 130),
 					'price'       => $price,
 					'special'     => $special,
 					'tax'         => $tax,


### PR DESCRIPTION
Fixed problem with "eating" of new lines in description preview. Also further will be provided some minor revisions.

For example, before it displayed like:
Size: 12"Peak: 800 WattsRMS: 200 Watts

And now it is:
Size: 12"
Peak: 800 Watts
RMS: 200 Watts